### PR TITLE
refactor: separate in files & start with unit status

### DIFF
--- a/integrations/sync/client/client.ts
+++ b/integrations/sync/client/client.ts
@@ -1,4 +1,4 @@
-const API_URL = GetConvar("snailycad_url", "null");
+export const API_URL = GetConvar("snailycad_url", "null");
 
 /**
  * send a message to the NUI with the API URL when a player spawns.
@@ -74,44 +74,5 @@ function formatDate(date: Date) {
   });
 }
 
-/**
- * authentication flow
- */
-
-// add client command suggestion
-emit(
-  "chat:addSuggestion",
-  "/sn-whoami",
-  "Shows your current SnailyCAD account username and ID that is connected to the game.",
-);
-
-emit(
-  "chat:addSuggestion",
-  "/sn-auth",
-  "Authenticate with your personal SnailyCAD API Token to interact with parts of it.",
-);
-
-// request to show the authentication flow modal
-onNet("sna-sync:request-authentication-flow", (identifiers: string[]) => {
-  SendNuiMessage(
-    JSON.stringify({
-      action: "sn:request-authentication-flow",
-      data: { url: API_URL, source, identifiers },
-    }),
-  );
-  SetNuiFocus(true, true);
-});
-
-// the user has logged in successfully
-RegisterNuiCallbackType("sna-sync:authentication-flow-success");
-on("__cfx_nui:sna-sync:authentication-flow-success", (data: unknown, cb: Function) => {
-  emitNet("sna-sync:request-user-save", data);
-  cb({ ok: true });
-});
-
-// the authentication flow has been closed
-RegisterNuiCallbackType("sna-sync:close-authentication-flow");
-on("__cfx_nui:sna-sync:close-authentication-flow", (_data: unknown, cb: Function) => {
-  SetNuiFocus(false, false);
-  cb({ ok: true });
-});
+import "./flows/auth";
+import "./flows/unit-status";

--- a/integrations/sync/client/flows/auth.ts
+++ b/integrations/sync/client/flows/auth.ts
@@ -1,0 +1,43 @@
+/**
+ * authentication flow
+ */
+
+import { API_URL } from "../client";
+
+// add client command suggestion
+emit(
+  "chat:addSuggestion",
+  "/sn-whoami",
+  "Shows your current SnailyCAD account username and ID that is connected to the game.",
+);
+
+emit(
+  "chat:addSuggestion",
+  "/sn-auth",
+  "Authenticate with your personal SnailyCAD API Token to interact with parts of it.",
+);
+
+// request to show the authentication flow modal
+onNet("sna-sync:request-authentication-flow", (identifiers: string[]) => {
+  SendNuiMessage(
+    JSON.stringify({
+      action: "sn:request-authentication-flow",
+      data: { url: API_URL, source, identifiers },
+    }),
+  );
+  SetNuiFocus(true, true);
+});
+
+// the user has logged in successfully
+RegisterNuiCallbackType("sna-sync:authentication-flow-success");
+on("__cfx_nui:sna-sync:authentication-flow-success", (data: unknown, cb: Function) => {
+  emitNet("sna-sync:request-user-save", data);
+  cb({ ok: true });
+});
+
+// the authentication flow has been closed
+RegisterNuiCallbackType("sna-sync:close-authentication-flow");
+on("__cfx_nui:sna-sync:close-authentication-flow", (_data: unknown, cb: Function) => {
+  SetNuiFocus(false, false);
+  cb({ ok: true });
+});

--- a/integrations/sync/client/flows/unit-status.ts
+++ b/integrations/sync/client/flows/unit-status.ts
@@ -1,0 +1,10 @@
+/**
+ * unit status flow
+ */
+
+emit("chat:addSuggestion", "/sn-active-unit", "This will show your active unit's name and status.");
+emit(
+  "chat:addSuggestion",
+  "/sn-set-status",
+  "This will open a menu and will allow you to select a status for your active unit.",
+);

--- a/integrations/sync/nui-dev/src/flows/authentication.ts
+++ b/integrations/sync/nui-dev/src/flows/authentication.ts
@@ -1,5 +1,5 @@
-import { handleClientCadRequest } from "./fetch.client";
-import { fetchNUI } from "./main";
+import { handleClientCadRequest } from "../fetch.client";
+import { fetchNUI } from "../main";
 
 export async function handleAuthenticationFlow(apiUrl: string, identifiers: string[]) {
   const closeAuthenticationFlowButton = document.getElementById("close-authentication-flow");

--- a/integrations/sync/nui-dev/src/main.ts
+++ b/integrations/sync/nui-dev/src/main.ts
@@ -1,5 +1,5 @@
 import { Socket, io } from "socket.io-client";
-import { handleAuthenticationFlow } from "./authentication";
+import { handleAuthenticationFlow } from "./flows/authentication";
 
 export interface NuiMessage {
   action: string;
@@ -20,22 +20,20 @@ window.addEventListener("message", (event: MessageEvent<NuiMessage>) => {
     return;
   }
 
-  console.log(identifiers);
-
   switch (event.data.action) {
     case "sn:initialize": {
       onSpawn(apiURL);
-
       break;
     }
     case "sn:request-authentication-flow": {
       const authenticationFlowElement = document.getElementById("authentication-flow");
       if (authenticationFlowElement && identifiers) {
         authenticationFlowElement.classList.remove("hidden");
-
         handleAuthenticationFlow(apiURL, identifiers);
       }
-
+      break;
+    }
+    case "sn:request-set-status-flow": {
       break;
     }
     default: {

--- a/integrations/sync/server/flows/auth.ts
+++ b/integrations/sync/server/flows/auth.ts
@@ -1,0 +1,74 @@
+import { cadRequest } from "~/utils/fetch.server";
+import { getPlayerIds } from "~/utils/get-player-ids.server";
+import { prependSnailyCAD } from "../server";
+
+// todo: add general docs for this plugin.
+
+/**
+ * authentication flow
+ */
+export interface User {
+  id: string;
+  username: string;
+  steamId: string | null;
+  discordId: string | null;
+  permissions: string[];
+}
+
+RegisterCommand(
+  "sn-whoami",
+  async (source: number) => {
+    CancelEvent();
+
+    const identifiers = getPlayerIds(source, "object");
+    const userId = identifiers.license;
+    const apiToken = GetResourceKvpString(`snailycad:${userId}:token`);
+
+    const response = await cadRequest("/user", "POST", { userApiToken: apiToken }).catch(
+      (error) => {
+        console.error(error);
+        return null;
+      },
+    );
+
+    const data = (await response?.body.json()) as User | null;
+
+    if (!data?.id) {
+      emitNet("chat:addMessage", source, {
+        args: [prependSnailyCAD("Please make sure you're authenticated. Use: ^5/sn-auth^7.")],
+      });
+      // todo: send client event that user doesn't exist
+      return;
+    }
+
+    emitNet("chat:addMessage", source, {
+      args: [
+        prependSnailyCAD(
+          `Your SnailyCAD username is ^5${data.username} ^7and user ID is ^5${data.id}^7.`,
+        ),
+      ],
+    });
+  },
+  false,
+);
+
+RegisterCommand(
+  "sn-auth",
+  (source: number) => {
+    CancelEvent();
+
+    const identifiers = getPlayerIds(source, "array");
+    emitNet("sna-sync:request-authentication-flow", source, identifiers);
+  },
+  false,
+);
+
+onNet("sna-sync:request-user-save", async (userData: { token: string }) => {
+  const identifiers = getPlayerIds(source, "object");
+  if (!identifiers.license) {
+    console.error("no license found");
+    return;
+  }
+
+  SetResourceKvp(`snailycad:${identifiers.license}:token`, userData.token);
+});

--- a/integrations/sync/server/flows/duty-status.ts
+++ b/integrations/sync/server/flows/duty-status.ts
@@ -1,0 +1,50 @@
+import { cadRequest } from "~/utils/fetch.server";
+import { getPlayerApiToken, prependSnailyCAD } from "../server";
+
+// todo: add general docs for this plugin.
+
+/**
+ * duty status
+ */
+export interface User {
+  id: string;
+  username: string;
+  steamId: string | null;
+  discordId: string | null;
+  permissions: string[];
+}
+
+RegisterCommand(
+  "sn-active-unit",
+  async (source: number) => {
+    CancelEvent();
+
+    const response = await cadRequest("/user?includeActiveUnit=true", "POST", {
+      userApiToken: getPlayerApiToken(source),
+    }).catch((error) => {
+      console.error(error);
+      return null;
+    });
+
+    const data = (await response?.body.json()) as (User & { unit: any }) | null;
+
+    if (!data?.id) {
+      emitNet("chat:addMessage", source, {
+        args: [prependSnailyCAD("Please make sure you're authenticated. Use: ^5/sn-auth^7.")],
+      });
+      return;
+    }
+
+    if (!data.unit) {
+      emitNet("chat:addMessage", source, {
+        args: [prependSnailyCAD("No active unit found. Go on-duty first.")],
+      });
+      return;
+    }
+
+    emitNet("chat:addMessage", source, {
+      args: [prependSnailyCAD(`Your active unit is ^5${"test"} ^7with status of ^5${"10-9"}^7.`)],
+    });
+  },
+  false,
+);

--- a/integrations/sync/server/server.ts
+++ b/integrations/sync/server/server.ts
@@ -1,75 +1,15 @@
-import { cadRequest } from "~/utils/fetch.server";
-import { getPlayerIds } from "~/utils/get-player-ids.server";
-
-type Response = {
-  id: string;
-  username: string;
-  steamId: string | null;
-  discordId: string | null;
-  permissions: string[];
-} | null;
-
-function prependSnailyCAD(text: string) {
+export function prependSnailyCAD(text: string) {
   return `^8^*[SnailyCAD]:^7^r ${text}`;
 }
 
-/**
- * authentication flow
- */
-RegisterCommand(
-  "sn-whoami",
-  async (source: number) => {
-    CancelEvent();
-
-    const identifiers = getPlayerIds(source, "object");
-    const userId = identifiers.license;
-    const apiToken = GetResourceKvpString(`snailycad:${userId}:token`);
-
-    const response = await cadRequest("/user", "POST", { userApiToken: apiToken }).catch(
-      (error) => {
-        console.error(error);
-        return null;
-      },
-    );
-
-    const data = (await response?.body.json()) as Response;
-
-    if (!data?.id) {
-      emitNet("chat:addMessage", source, {
-        args: [prependSnailyCAD("Please make sure you're authenticated. Use: ^5/sn-auth^7.")],
-      });
-      // todo: send client event that user doesn't exist
-      return;
-    }
-
-    emitNet("chat:addMessage", source, {
-      args: [
-        prependSnailyCAD(
-          `Your SnailyCAD username is ^5${data.username} ^7and user ID is ^5${data.id}^7.`,
-        ),
-      ],
-    });
-  },
-  false,
-);
-
-RegisterCommand(
-  "sn-auth",
-  (source: number) => {
-    CancelEvent();
-
-    const identifiers = getPlayerIds(source, "array");
-    emitNet("sna-sync:request-authentication-flow", source, identifiers);
-  },
-  false,
-);
-
-onNet("sna-sync:request-user-save", async (userData: { token: string }) => {
+export function getPlayerApiToken(source: number) {
   const identifiers = getPlayerIds(source, "object");
-  if (!identifiers.license) {
-    console.error("no license found");
-    return;
-  }
+  const userId = identifiers.license;
+  const apiToken = GetResourceKvpString(`snailycad:${userId}:token`);
 
-  SetResourceKvp(`snailycad:${identifiers.license}:token`, userData.token);
-});
+  return apiToken;
+}
+
+import { getPlayerIds } from "~/utils/get-player-ids.server";
+import "./flows/auth";
+import "./flows/duty-status";


### PR DESCRIPTION
This PR includes:

- Allow players to set a status for their active SnailyCAD unit.
- Allow players to view their active SnailyCAD unit.

closes #73 