### PR TITLE
Added feature to automatically make route to call postal

### DIFF
--- a/integrations/sync/client/flows/911-call-attach.ts
+++ b/integrations/sync/client/flows/911-call-attach.ts
@@ -28,3 +28,31 @@ onNet(
     SetNuiFocus(true, true);
   },
 );
+
+var POSTAL_COMMAND_DEFAULT = GetConvar("postal_command", "null");
+onNet("sna-sync:attach-postal", (
+  postal: string
+) => {
+  const PostalCode = Number(postal);
+
+  if (POSTAL_COMMAND_DEFAULT === "null") {
+    console.error(`
+    ---------------------------------------
+  
+  [${GetCurrentResourceName()}] Failed to find the "postal_command" convar in your server.cfg. Please make sure you are using \`setr\` and not \`set\`:
+  
+  \`setr postal_command "<your-command-here>" \`
+  
+    ---------------------------------------`);
+  };
+
+  if (PostalCode != null && PostalCode > 0){
+    ExecuteCommand(`${POSTAL_COMMAND_DEFAULT} ${PostalCode}`);
+  } else {
+    emit('chat:addMessage', {
+      color: [255, 0, 0],
+      multiline: true,
+      args: ['SnailyCAD', 'An error occured while making route to call postal']
+    });
+  };
+})

--- a/integrations/sync/server/flows/911-call-attach.ts
+++ b/integrations/sync/server/flows/911-call-attach.ts
@@ -109,6 +109,7 @@ onNet(
           ),
         ],
       });
+      emitNet("sna-sync:attach-postal", source2, updatedCall.postal);
     } else {
       emitNet("chat:addMessage", source, {
         args: [

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -99,6 +99,8 @@ export enum ClientEvents {
   RequestTrafficStopFlow = "sna-sync:request-traffic-stop-flow",
 
   CreateNotification = "sna-sync:create-notification",
+
+  AutoPostalOnAttach = "sna-sync:attach-postal"
 }
 
 export enum NuiEvents {


### PR DESCRIPTION
Originall suggestion threads >> https://discord.com/channels/792479048457912360/1221734388920746034 and https://discord.com/channels/792479048457912360/1251110184022052896

Notes:
- Tested on my server with different scenarios (without convar, with convar, with set Instead of setr, different postals, calls etc.)
- Supports different commands for making route to postal. All needed is to set up `setr postal_command "<your-postal-command>"` to server.cfg