### PR TITLE
fix(sync): :bug: sync now uses the actual resource name

### DIFF
--- a/integrations/sync/nui-dev/src/main.ts
+++ b/integrations/sync/nui-dev/src/main.ts
@@ -95,17 +95,15 @@ export async function fetchNUI(eventName: NuiEvents, data = {}) {
 
     const resourceName = GetParentResourceName();
     const url = `https://${resourceName}/${eventName}`;
-    const response = await new Promise((resolve, reject) => {
-      fetch(url, options)
-        .then((value) => resolve(value))
-        .catch((reason) => {
-          reject(new Error(`Failed to fetch url: ("${url}"), Reason: ${reason}`));
-        });
-    });
+    try {
+      const response = await fetch(url, options);
 
-    console.log("[`sna-sync-nui`][outgoing]:", eventName);
+      console.log("[`sna-sync-nui`][outgoing]:", eventName);
 
-    return response;
+      return response;
+    } catch (reason) {
+      throw new Error(`Failed to fetch url: ("${url}"), Reason: ${reason}`);
+    }
   } catch (err) {
     console.error(err);
     return null;

--- a/integrations/sync/nui-dev/src/main.ts
+++ b/integrations/sync/nui-dev/src/main.ts
@@ -93,7 +93,8 @@ export async function fetchNUI(eventName: NuiEvents, data = {}) {
       body: JSON.stringify(data),
     } as const;
 
-    const resourceName = GetParentResourceName();
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    const resourceName = GetParentResourceName ? GetParentResourceName() : "sna-sync";
     const url = `https://${resourceName}/${eventName}`;
     try {
       const response = await fetch(url, options);

--- a/integrations/sync/nui-dev/src/main.ts
+++ b/integrations/sync/nui-dev/src/main.ts
@@ -17,9 +17,7 @@ export interface NuiMessage {
 }
 
 declare global {
-  interface Window {
-    GetCurrentResourceName?(): string;
-  }
+  function GetParentResourceName(): string;
 }
 
 window.addEventListener("message", (event: MessageEvent<NuiMessage>) => {
@@ -95,8 +93,15 @@ export async function fetchNUI(eventName: NuiEvents, data = {}) {
       body: JSON.stringify(data),
     } as const;
 
-    const resourceName = window.GetCurrentResourceName?.() ?? "sna-sync";
-    const response = await fetch(`https://${resourceName}/${eventName}`, options);
+    const resourceName = GetParentResourceName();
+    const url = `https://${resourceName}/${eventName}`;
+    const response = await new Promise((resolve, reject) => {
+      fetch(url, options)
+        .then((value) => resolve(value))
+        .catch((reason) => {
+          reject(new Error(`Failed to fetch url: ("${url}"), Reason: ${reason}`));
+        });
+    });
 
     console.log("[`sna-sync-nui`][outgoing]:", eventName);
 


### PR DESCRIPTION
sna-sync now uses the GetParentResourceName in order to get the name of the resource. Also added error handling that prints out the url that is in the fetch request.